### PR TITLE
Mqtt last will topic handling & code improvements

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -9172,7 +9172,7 @@ return false;
  *   none
  */
 #ifdef MQTT
-const String& mqtt_get_will_topic() {
+const String mqtt_get_will_topic() {
   // Build (Last) Will Topic
   String MQTTLWTopic = "";
   if (MQTTTopicPrefix[0]) {

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -9141,7 +9141,7 @@ boolean mqtt_connect() {
         printlnToDebug(PSTR("Failed to connect to MQTT broker, retrying..."));
       } else {
         printlnToDebug(PSTR("Connect to MQTT broker, updating will topic"));
-        printFmtToDebug(PSTR("Will topic: %s"), MQTTWillTopic.c_str());
+        printFmtToDebug(PSTR("Will topic: %s\r\n"), MQTTWillTopic.c_str());
         const char* mqtt_subscr;
         if (MQTTTopicPrefix[0]) {mqtt_subscr = MQTTTopicPrefix;} else {mqtt_subscr="fromBroker";}
         MQTTPubSubClient->subscribe(mqtt_subscr);   //Luposoft: set the topic listen to
@@ -9199,7 +9199,7 @@ void mqtt_disconnect() {
     if (MQTTPubSubClient->connected()) {
       String MQTTWillTopic = mqtt_get_will_topic();
       printlnToDebug(PSTR("Disconnect from MQTT broker, updating will topic"));
-      printFmtToDebug(PSTR("Will topic: %s"), MQTTWillTopic.c_str());
+      printFmtToDebug(PSTR("Will topic: %s\r\n"), MQTTWillTopic.c_str());
       MQTTPubSubClient->publish(MQTTWillTopic.c_str(), PSTR("offline"), true);
       MQTTPubSubClient->disconnect();
     } else {

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -9059,7 +9059,7 @@ void mqtt_sendtoBroker(int param) {
     char tbuf[20];
     sprintf_P(tbuf, PSTR("\"%d\":\""), param);
     MQTTPayload.concat(tbuf);
-    if (decodedTelegram.type == VT_ENUM || decodedTelegram.type == VT_BIT || decodedTelegram.type == VT_ERRORCODE || decodedTelegram.type == VT_DATETIME) {
+    if (decodedTelegram.type == VT_ENUM || decodedTelegram.type == VT_BIT || decodedTelegram.type == VT_ERRORCODE || decodedTelegram.type == VT_DATETIME || decodedTelegram.type == VT_WEEKDAY) {
 //---- we really need build_pvalstr(0) or we need decodedTelegram.value or decodedTelegram.enumdescaddr ? ----
       MQTTPayload.concat(String(build_pvalstr(0)));
     } else {
@@ -9067,7 +9067,7 @@ void mqtt_sendtoBroker(int param) {
     }
     MQTTPayload.concat(F("\""));
   } else { //plain text
-    if (decodedTelegram.type == VT_ENUM || decodedTelegram.type == VT_BIT || decodedTelegram.type == VT_ERRORCODE || decodedTelegram.type == VT_DATETIME) {
+    if (decodedTelegram.type == VT_ENUM || decodedTelegram.type == VT_BIT || decodedTelegram.type == VT_ERRORCODE || decodedTelegram.type == VT_DATETIME || decodedTelegram.type == VT_WEEKDAY) {
 //---- we really need build_pvalstr(0) or we need decodedTelegram.value or decodedTelegram.enumdescaddr ? ----
       MQTTPubSubClient->publish(MQTTTopic.c_str(), build_pvalstr(0));
     } else {

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -9026,51 +9026,49 @@ void mqtt_sendtoBroker(int param) {
       MQTTPayload.concat(F("\":{\"id\":"));
   }
   boolean is_first = true;
-  if (mqtt_connect()) { // This call seems unneccessary
-    if (is_first) {is_first = false;} else {MQTTPayload.concat(F(","));}
-    if (MQTTTopicPrefix[0]) {
-      MQTTTopic = MQTTTopicPrefix;
-      MQTTTopic.concat(F("/"));
-    }
-    else
-      MQTTTopic = "BSB-LAN/";
-    // use the sub-topic "json" if json output is enabled
-    if (mqtt_mode == 2 || mqtt_mode == 3)
-      MQTTTopic.concat(F("json"));
-    else
-      MQTTTopic.concat(String(param));
+  if (is_first) {is_first = false;} else {MQTTPayload.concat(F(","));}
+  if (MQTTTopicPrefix[0]) {
+    MQTTTopic = MQTTTopicPrefix;
+    MQTTTopic.concat(F("/"));
+  }
+  else
+    MQTTTopic = "BSB-LAN/";
+  // use the sub-topic "json" if json output is enabled
+  if (mqtt_mode == 2 || mqtt_mode == 3)
+    MQTTTopic.concat(F("json"));
+  else
+    MQTTTopic.concat(String(param));
 
-    query(param);
-    if (mqtt_mode == 3) { // Build the json doc on the fly
-      int len = 0;
-      outBuf[len] = 0;
-      len += sprintf_P(outBuf + len, PSTR("%d,\"name\":\""), param);
-      len += strlen(strcpy_PF(outBuf + len, decodedTelegram.prognrdescaddr));
-      len += sprintf_P(outBuf + len, PSTR("\",\"value\": \"%s\",\"desc\": \""), decodedTelegram.value);
-      if (decodedTelegram.data_type == DT_ENUM && decodedTelegram.enumdescaddr) {
-        len += strlen(strcpy_PF(outBuf + len, decodedTelegram.enumdescaddr));
-      }
-      len += sprintf_P(outBuf + len, PSTR("\",\"unit\": \"%s\",\"error\": %d"), decodedTelegram.unit, decodedTelegram.error);
-      MQTTPayload.concat(outBuf);
-    } else if (mqtt_mode == 2) { // Build the json doc on the fly
-      char tbuf[20];
-      sprintf_P(tbuf, PSTR("\"%d\":\""), param);
-      MQTTPayload.concat(tbuf);
-      if (decodedTelegram.type == VT_ENUM || decodedTelegram.type == VT_BIT || decodedTelegram.type == VT_ERRORCODE || decodedTelegram.type == VT_DATETIME || decodedTelegram.type == VT_WEEKDAY) {
-//---- we really need build_pvalstr(0) or we need decodedTelegram.value or decodedTelegram.enumdescaddr ? ----
-        MQTTPayload.concat(String(build_pvalstr(0)));
-      } else {
-        MQTTPayload.concat(String(decodedTelegram.value));
-      }
-      MQTTPayload.concat(F("\""));
-    } else { //plain text
-      if (decodedTelegram.type == VT_ENUM || decodedTelegram.type == VT_BIT || decodedTelegram.type == VT_ERRORCODE || decodedTelegram.type == VT_DATETIME || decodedTelegram.type == VT_WEEKDAY) {
-//---- we really need build_pvalstr(0) or we need decodedTelegram.value or decodedTelegram.enumdescaddr ? ----
-        MQTTPubSubClient->publish(MQTTTopic.c_str(), build_pvalstr(0));
-      }
-      else
-        MQTTPubSubClient->publish(MQTTTopic.c_str(), decodedTelegram.value);
+  query(param);
+  if (mqtt_mode == 3) { // Build the json doc on the fly
+    int len = 0;
+    outBuf[len] = 0;
+    len += sprintf_P(outBuf + len, PSTR("%d,\"name\":\""), param);
+    len += strlen(strcpy_PF(outBuf + len, decodedTelegram.prognrdescaddr));
+    len += sprintf_P(outBuf + len, PSTR("\",\"value\": \"%s\",\"desc\": \""), decodedTelegram.value);
+    if (decodedTelegram.data_type == DT_ENUM && decodedTelegram.enumdescaddr) {
+      len += strlen(strcpy_PF(outBuf + len, decodedTelegram.enumdescaddr));
     }
+    len += sprintf_P(outBuf + len, PSTR("\",\"unit\": \"%s\",\"error\": %d"), decodedTelegram.unit, decodedTelegram.error);
+    MQTTPayload.concat(outBuf);
+  } else if (mqtt_mode == 2) { // Build the json doc on the fly
+    char tbuf[20];
+    sprintf_P(tbuf, PSTR("\"%d\":\""), param);
+    MQTTPayload.concat(tbuf);
+    if (decodedTelegram.type == VT_ENUM || decodedTelegram.type == VT_BIT || decodedTelegram.type == VT_ERRORCODE || decodedTelegram.type == VT_DATETIME) {
+//---- we really need build_pvalstr(0) or we need decodedTelegram.value or decodedTelegram.enumdescaddr ? ----
+      MQTTPayload.concat(String(build_pvalstr(0)));
+    } else {
+      MQTTPayload.concat(String(decodedTelegram.value));
+    }
+    MQTTPayload.concat(F("\""));
+  } else { //plain text
+    if (decodedTelegram.type == VT_ENUM || decodedTelegram.type == VT_BIT || decodedTelegram.type == VT_ERRORCODE || decodedTelegram.type == VT_DATETIME) {
+//---- we really need build_pvalstr(0) or we need decodedTelegram.value or decodedTelegram.enumdescaddr ? ----
+      MQTTPubSubClient->publish(MQTTTopic.c_str(), build_pvalstr(0));
+    }
+    else
+      MQTTPubSubClient->publish(MQTTTopic.c_str(), decodedTelegram.value);
   }
   // End of mqtt if loop so close off the json and publish
   if (mqtt_mode == 2 || mqtt_mode == 3) {

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -9143,7 +9143,8 @@ boolean mqtt_connect()
       }
       else
       {
-        printlnToDebug(PSTR("Connect to MQTT broker"));
+        printlnToDebug(PSTR("Connect to MQTT broker, updating will topic"));
+        printFmtToDebug(PSTR("Will topic: %s"), MQTTWillTopic.c_str());
         const char* mqtt_subscr;
         if (MQTTTopicPrefix[0]) {mqtt_subscr = MQTTTopicPrefix;} else {mqtt_subscr="fromBroker";}
         MQTTPubSubClient->subscribe(mqtt_subscr);   //Luposoft: set the topic listen to
@@ -9171,7 +9172,7 @@ return false;
  *   none
  */
 #ifdef MQTT
-String mqtt_get_will_topic() {
+const String& mqtt_get_will_topic() {
   // Build (Last) Will Topic
   String MQTTLWTopic = "";
   if (MQTTTopicPrefix[0]) {
@@ -9200,10 +9201,14 @@ String mqtt_get_will_topic() {
 #ifdef MQTT
 void mqtt_disconnect() {
   if (MQTTPubSubClient) {
-    printlnToDebug(PSTR("Disconnect from MQTT broker, updating will topic"));
     if (MQTTPubSubClient->connected()) {
-      MQTTPubSubClient->publish(mqtt_get_will_topic().c_str(), PSTR("offline"), true);
+      String MQTTWillTopic = mqtt_get_will_topic();
+      printlnToDebug(PSTR("Disconnect from MQTT broker, updating will topic"));
+      printFmtToDebug(PSTR("Will topic: %s"), MQTTWillTopic.c_str());
+      MQTTPubSubClient->publish(MQTTWillTopic.c_str(), PSTR("offline"), true);
       MQTTPubSubClient->disconnect();
+    } else {
+      printlnToDebug(PSTR("Dropping unconnected MQTT client"));
     }
     delete MQTTPubSubClient;
     MQTTPubSubClient = NULL;

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -8658,8 +8658,7 @@ uint8_t pps_offset = 0;
           mqtt_sendtoBroker(log_parameters[i]);  //Luposoft, put hole unchanged code in new function mqtt_sendtoBroker to use it at other points as well
         }
       }
-      if (MQTTPubSubClient != NULL && !mqtt_mode)  //Luposoft: user may disable MQTT through web interface
-      {
+      if (MQTTPubSubClient != NULL && !mqtt_mode) { //Luposoft: user may disable MQTT through web interface
         // Actual disconnect will be handled a few lines below through mqtt_disconnect().
         printlnToDebug(PSTR("MQTT will be disconnected on order through web interface"));
       }
@@ -9025,8 +9024,13 @@ void mqtt_sendtoBroker(int param) {
     if (mqtt_mode == 3)
       MQTTPayload.concat(F("\":{\"id\":"));
   }
+
   boolean is_first = true;
-  if (is_first) {is_first = false;} else {MQTTPayload.concat(F(","));}
+  if (is_first)
+    is_first = false;
+  else
+    MQTTPayload.concat(F(","));
+    
   if (MQTTTopicPrefix[0]) {
     MQTTTopic = MQTTTopicPrefix;
     MQTTTopic.concat(F("/"));
@@ -9066,9 +9070,9 @@ void mqtt_sendtoBroker(int param) {
     if (decodedTelegram.type == VT_ENUM || decodedTelegram.type == VT_BIT || decodedTelegram.type == VT_ERRORCODE || decodedTelegram.type == VT_DATETIME) {
 //---- we really need build_pvalstr(0) or we need decodedTelegram.value or decodedTelegram.enumdescaddr ? ----
       MQTTPubSubClient->publish(MQTTTopic.c_str(), build_pvalstr(0));
-    }
-    else
+    } else {
       MQTTPubSubClient->publish(MQTTTopic.c_str(), decodedTelegram.value);
+    }
   }
   // End of mqtt if loop so close off the json and publish
   if (mqtt_mode == 2 || mqtt_mode == 3) {
@@ -9105,10 +9109,8 @@ void mqtt_sendtoBroker(int param) {
  *  MQTT instance
  * *************************************************************** */
 #ifdef MQTT
-boolean mqtt_connect()
-{
-  if(MQTTPubSubClient == NULL)
-  {
+boolean mqtt_connect() {
+  if(MQTTPubSubClient == NULL) {
     mqtt_client= new ComClient();
     uint16_t bufsize;
     MQTTPubSubClient = new PubSubClient(mqtt_client[0]);
@@ -9120,8 +9122,7 @@ boolean mqtt_connect()
     }
     MQTTPubSubClient->setBufferSize(bufsize);
   }
-  if (!MQTTPubSubClient->connected())
-  {
+  if (!MQTTPubSubClient->connected()) {
     char* MQTTUser = NULL;
     if(MQTTUsername[0])
       MQTTUser = MQTTUsername;
@@ -9132,17 +9133,13 @@ boolean mqtt_connect()
     MQTTPubSubClient->setServer(MQTTBroker, 1883);
     String MQTTWillTopic = mqtt_get_will_topic();
     int retries = 0;
-    while (!MQTTPubSubClient->connected() && retries < 3)
-    {
+    while (!MQTTPubSubClient->connected() && retries < 3) {
       MQTTPubSubClient->connect(PSTR("BSB-LAN"), MQTTUser, MQTTPass, MQTTWillTopic.c_str(), 0, true, PSTR("offline"));
       retries++;
-      if (!MQTTPubSubClient->connected())
-      {
+      if (!MQTTPubSubClient->connected()) {
         delay(1000);
         printlnToDebug(PSTR("Failed to connect to MQTT broker, retrying..."));
-      }
-      else
-      {
+      } else {
         printlnToDebug(PSTR("Connect to MQTT broker, updating will topic"));
         printFmtToDebug(PSTR("Will topic: %s"), MQTTWillTopic.c_str());
         const char* mqtt_subscr;
@@ -9154,12 +9151,10 @@ boolean mqtt_connect()
         return true;
       }
     }
-  }
-  else
-  {
+  } else {
     return true;
   }
-return false;
+  return false;
 }
 #endif
 /* Function: mqtt_get_will_topic()
@@ -9263,15 +9258,15 @@ void mqtt_callback(char* topic, byte* payload, unsigned int length) {
   if (MQTTTopicPrefix[0]) {
     mqtt_Topic = MQTTTopicPrefix;
     mqtt_Topic.concat(F("/"));
+  } else {
+    mqtt_Topic = "BSB-LAN/";
   }
-  else mqtt_Topic = "BSB-LAN/";
   mqtt_Topic.concat(F("MQTT"));
   MQTTPubSubClient->publish(mqtt_Topic.c_str(), C_value);
 
   if (firstsign==' ') { //query
     printFmtToDebug(PSTR("%d \r\n"), I_line);
-  }
-  else { //command to heater
+  } else { //command to heater
     C_payload=strchr(C_payload,'=');
     C_payload++;
     printFmtToDebug(PSTR("%d=%s \r\n"), I_line, C_payload);


### PR DESCRIPTION
This PR adds a [last will/status](https://www.hivemq.com/blog/mqtt-essentials-part-9-last-will-and-testament/) topic handling. This way, we always have the current state of the MQTT device available at the broker. Tools like Home Assistant (HA) use this to determine, if the integration in question is available or currently down. The will/status subtopic used is "status" below the configured prefix, f.x. "BSB-LAN/status". Values can be "online" and "offline". 

To make this easier, I took the liberty to refactor the code a bit:

Improved the mqtt_connect code. We allocate a bit less RAM on each call (as we're connected almost all of the time). When connecting, we register our last will & testament at the status topic. After a successful connection, we update the status topic to online and we're good.

Extracted the (duplicated) disconnect code and centralized it into mqtt_disconnect. When disconnecting, we set our status topic to offline and cleanup afterwards. Added logging to this location as well. We call the disconnect upon board reset as well so that we exit the MQTT connection gracefully and go offline immediately and not via timeout.

Created mqtt_get_will_topic to centralize will topic parsing. This should make it easy to make it configurable later on.

An excess mqtt_connect call has been removed from mqtt_sendtoBroker. Once we enter the latter call we can safely assume that we're already connected. loop checks this already beforehand, and if we come out of the callback, we are connected by definition as well.

Stramlined disconnect handling in the MQTT calls in the loop to break it down to a single mqtt_disconnect.
