### PR TITLE
Added Brötje WGB EVO 20i and WGB ProEVO 15C

### DIFF
--- a/BSB_LAN/BSB_LAN_config.h
+++ b/BSB_LAN/BSB_LAN_config.h
@@ -1,0 +1,1 @@
+../../BSB_LAN_config.h


### PR DESCRIPTION
Hi,
I added the family and variant IDs for the following heaters:
- Brötje WGB EVO 20i: 193, 5 (our current heater)
- Brötje EcoTherm Plus WGB Pro EVO 15 C: 98, 100 (our old one)

Greetings
J.


