### PR TITLE
Fix for Issue #513. Correct timestamps for log files. Fix for new SdFat

### DIFF
--- a/.github/workflows/platformio-esp32.yaml
+++ b/.github/workflows/platformio-esp32.yaml
@@ -40,6 +40,7 @@ jobs:
     - name: Setup config
       run: |
         rm -R BSB_LAN/src/WiFiSpi
+        rm -R BSB_LAN/src/Time
         cp BSB_LAN/BSB_LAN_config.h.default BSB_LAN/BSB_LAN_config.h
         cp BSB_LAN/BSB_LAN_custom_defs.h.default BSB_LAN/BSB_LAN_custom_defs.h
 

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -3858,7 +3858,7 @@ char *build_pvalstr(bool extended) {
     if(roundf(decodedTelegram.prognr * 10) != roundf(decodedTelegram.prognr) * 10)
       len+=sprintf_P(outBuf, PSTR("%4.1f "), decodedTelegram.prognr);
     else
-      len+=sprintf_P(outBuf, PSTR("%d "), roundf(decodedTelegram.prognr));
+      len+=sprintf_P(outBuf, PSTR("%d "), (int)roundf(decodedTelegram.prognr));
 
     len+=strlen(strcpy_PF(outBuf + len, decodedTelegram.catdescaddr));
     len+=strlen(strcpy_P(outBuf + len, PSTR(" - ")));

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -3004,7 +3004,13 @@ void generateJSONwithConfig() {
  *   none
  * *************************************************************** */
 char *GetDateTime(char *date) {
+#if defined(ESP32)
+  struct tm now;
+  getLocalTime(&now,0);
+  sprintf_P(date,PSTR("%02d.%02d.%d %02d:%02d:%02d"),now.tm_mday,now.tm_mon,now.tm_year + 1900,now.tm_hour,now.tm_min,now.tm_sec);
+#else
   sprintf_P(date,PSTR("%02d.%02d.%d %02d:%02d:%02d"),day(),month(),year(),hour(),minute(),second());
+#endif
   date[19] = 0;
   return date;
 }
@@ -3261,7 +3267,13 @@ int set(int line      // the ProgNr of the heater parameter
       {
         int dow = atoi(val);
         pps_values[PPS_DOW] = dow;
+      #if defined(ESP32)
+        struct tm now;
+        getLocalTime(&now,0);
+        setTime(now.tm_hour,now.tm_min,now.tm_sec, dow, 1, 2018);
+      #else
         setTime(hour(), minute(), second(), dow, 1, 2018);
+      #endif
 //        printFmtToDebug(PSTR("Setting weekday to %d\r\n"), weekday());
         pps_wday_set = true;
         break;

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -3855,11 +3855,11 @@ char *build_pvalstr(bool extended) {
   int len = 0;
   outBuf[len] = 0;
   if (extended && decodedTelegram.error != 257) {
-#if !(defined ESP32)
-    len+=sprintf_P(outBuf, PSTR("%4.1f "), decodedTelegram.prognr);
-#else
-    len+=sprintf_P(outBuf, PSTR("%4.1f "), decodedTelegram.prognr);
-#endif
+    if(roundf(decodedTelegram.prognr * 10) != roundf(decodedTelegram.prognr) * 10)
+      len+=sprintf_P(outBuf, PSTR("%4.1f "), decodedTelegram.prognr);
+    else
+      len+=sprintf_P(outBuf, PSTR("%d "), roundf(decodedTelegram.prognr));
+
     len+=strlen(strcpy_PF(outBuf + len, decodedTelegram.catdescaddr));
     len+=strlen(strcpy_P(outBuf + len, PSTR(" - ")));
 #ifdef AVERAGES

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -6666,7 +6666,12 @@ void loop() {
           query(log_parameters[i]);
           if (decodedTelegram.prognr < 0) continue;
           if (LoggingMode & CF_LOGMODE_UDP) udp_log.beginPacket(broadcast_ip, UDP_LOG_PORT);
-          outBufLen += sprintf_P(outBuf + outBufLen, PSTR("%lu;%s;%.1f;"), millis(), GetDateTime(outBuf + outBufLen + 80), log_parameters[i]);
+          outBufLen += sprintf_P(outBuf + outBufLen, PSTR("%lu;%s;"), millis(), GetDateTime(outBuf + outBufLen + 80));
+          if(roundf(log_parameters[i] * 10) != roundf(log_parameters[i]) * 10)
+            outBufLen += sprintf_P(outBuf + outBufLen, PSTR("%.1f;"), log_parameters[i]);
+          else
+            outBufLen += sprintf_P(outBuf + outBufLen, PSTR("%d;"), (int)log_parameters[i]);
+
 #ifdef AVERAGES
           if ((log_parameters[i] >= BSP_AVERAGES && log_parameters[i] < BSP_AVERAGES + numAverages)) {
             //averages

--- a/BSB_LAN/include/mqtt_handler.h
+++ b/BSB_LAN/include/mqtt_handler.h
@@ -49,7 +49,10 @@ void mqtt_sendtoBroker(float param) {
   if (mqtt_mode == 2 || mqtt_mode == 3) {
     MQTTTopic.concat(F("json"));
   } else {
-    MQTTTopic.concat(String(param));
+    if(roundf(param * 10) != roundf(param) * 10)
+      MQTTTopic.concat(String(param, 1));
+    else
+      MQTTTopic.concat(String(param, 0));
   }
   query(param);
   if (mqtt_mode == 3) { // Build the json doc on the fly

--- a/BSB_LAN/include/print2webclient.h
+++ b/BSB_LAN/include/print2webclient.h
@@ -75,7 +75,7 @@ int printFmtToWebClient(const char *format, ...) {
 
 void printToWebClient_prognrdescaddr() {
   if (decodedTelegram.prognr < 0) return;
-  if (decodedTelegram.prognr >= 20050 && decodedTelegram.prognr < 20100) {
+  if (decodedTelegram.prognr >= BSP_AVERAGES && decodedTelegram.prognr < BSP_DHT22) {
     printToWebClient(PSTR(STR_24A_TEXT));
     printToWebClient(PSTR(". "));
   }

--- a/BSB_LAN/include/print_ipwe.h
+++ b/BSB_LAN/include/print_ipwe.h
@@ -42,7 +42,7 @@
      for (int i=0; i<numAverages; i++) {
        if (avg_parameters[i] > 0) {
          counter++;
-         query(20050 + i);
+         query(BSP_AVERAGES + i);
          printFmtToWebClient(PSTR("<tr><td>T<br></td><td>%d"), counter);
          printToWebClient(PSTR("<br></td><td>"));
          printToWebClient_prognrdescaddr();
@@ -61,9 +61,9 @@
      // output of one wire sensors
      for (i=0;i<numSensors * 2;i += 2) {
        printFmtToWebClient(PSTR("<tr><td>T<br></td><td>%d<br></td><td>"), counter);
-       query(i + 20300);
+       query(i + BSP_ONEWIRE);
        printToWebClient(decodedTelegram.value);
-       query(i + 20301);
+       query(i + BSP_ONEWIRE + 1);
        printFmtToWebClient(PSTR("<br></td><td>%s<br></td>"), decodedTelegram.value);
        printToWebClient(STR_IPWEZERO);
        printToWebClient(STR_IPWEZERO);
@@ -78,7 +78,7 @@
    int numDHTSensors = sizeof(DHT_Pins) / sizeof(DHT_Pins[0]);
    for (i=0;i<numDHTSensors;i++) {
      if (!DHT_Pins[i]) continue;
-     query(20101 + i * 4);
+     query(BSP_DHT22 + 1 + i * 4);
      counter++;
      printFmtToWebClient(PSTR("<tr><td>T<br></td><td>%d<br></td><td>"), counter);
      printFmtToWebClient(PSTR("DHT sensor %d temperature"), DHT_Pins[i]);
@@ -88,7 +88,7 @@
      printToWebClient(STR_IPWEZERO);
      printToWebClient(PSTR("</tr>"));
      counter++;
-     query(20102 + i * 4);
+     query(BSP_DHT22 + 2 + i * 4);
      printFmtToWebClient(PSTR("<tr><td>F<br></td><td>%d<br></td><td>"), counter);
      printFmtToWebClient(PSTR("DHT sensor %d humidity<br></td>"), DHT_Pins[i]);
      printToWebClient(STR_IPWEZERO);

--- a/BSB_LAN/src/esp32_time.h
+++ b/BSB_LAN/src/esp32_time.h
@@ -1,0 +1,59 @@
+//time library wrapper for ESP32 with TimeLib compatibility
+#if defined(ESP32)
+#include <time.h>
+#include <sys/time.h>
+void setTime(int hr,int min,int sec,int day, int month, int yr){
+  struct tm t = {0};        // Initalize to all 0's
+  t.tm_year = yr - 1900;    // This is year-1900, so 121 = 2021
+  t.tm_mon = month - 1;
+  t.tm_mday = day;
+  t.tm_hour = hr;
+  t.tm_min = min;
+  t.tm_sec = sec;
+  time_t epoch_ts = mktime(&t);
+  struct timeval tv_ts = {.tv_sec = epoch_ts};
+  settimeofday(&tv_ts, NULL);
+}
+
+int year(){
+  struct tm now;
+  getLocalTime(&now,0);
+  return now.tm_year;
+}
+
+int month(){
+  struct tm now;
+  getLocalTime(&now,0);
+  return now.tm_mon;
+}
+
+int day(){
+  struct tm now;
+  getLocalTime(&now,0);
+  return now.tm_mday;
+}
+
+int hour(){
+  struct tm now;
+  getLocalTime(&now,0);
+  return now.tm_hour;
+}
+
+int minute(){
+  struct tm now;
+  getLocalTime(&now,0);
+  return now.tm_min;
+}
+
+int second(){
+  struct tm now;
+  getLocalTime(&now,0);
+  return now.tm_sec;
+}
+int weekday() {   // Sunday is day 1
+  struct tm now;
+  getLocalTime(&now,0);
+  return now.tm_wday;
+}
+
+#endif

--- a/BSB_LAN/src/esp32_time.h
+++ b/BSB_LAN/src/esp32_time.h
@@ -18,7 +18,7 @@ void setTime(int hr,int min,int sec,int day, int month, int yr){
 int year(){
   struct tm now;
   getLocalTime(&now,0);
-  return now.tm_year;
+  return now.tm_year + 1900;
 }
 
 int month(){


### PR DESCRIPTION
Fix for Issue https://github.com/fredlcore/BSB-LAN/issues/513
Adaptive (int/float) program numbers printing for web interface, MQTT, UDP/file logging.
Due: callback for SdFat library added for setup correct timestamps on log files.
ESP32: TimeLib library wrapper added. This wrapper can't be used with TimeLib in same time on ESP32. Wrapper will allow to set correct timestamps on log files.
