### PR TITLE
Use 4 KB buffer in transmitFile() on ESP32

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -4551,7 +4551,10 @@ uint16_t setPPS(uint8_t pps_index, int16_t value) {
  * *************************************************************** */
 void transmitFile(File dataFile) {
   int logbuflen = (OUTBUF_USEFUL_LEN + OUTBUF_LEN > 1024)?1024:(OUTBUF_USEFUL_LEN + OUTBUF_LEN);
-  byte *buf = (byte*)malloc(4<<10);  // try to use 4 KB buffer, for improved transfer rates
+  byte *buf = 0;
+#ifdef ESP32 // Arduino seems to have problems with the bigger, malloc'ed buffer
+  buf = (byte*)malloc(4<<10);  // try to use 4 KB buffer, for improved transfer rates
+#endif
   if (buf) logbuflen=4<<10; else buf=(byte*)bigBuff;  // fall back to static buffer, if necessary
   flushToWebClient();
   int chars_read = dataFile.read(buf, logbuflen);

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -4553,9 +4553,9 @@ void transmitFile(File dataFile) {
   int logbuflen = (OUTBUF_USEFUL_LEN + OUTBUF_LEN > 1024)?1024:(OUTBUF_USEFUL_LEN + OUTBUF_LEN);
   byte *buf = 0;
 #ifdef ESP32 // Arduino seems to have problems with the bigger, malloc'ed buffer
-  buf = (byte*)malloc(4<<10);  // try to use 4 KB buffer, for improved transfer rates
+  buf = (byte*)malloc(4096);  // try to use 4 KB buffer, for improved transfer rates
 #endif
-  if (buf) logbuflen=4<<10; else buf=(byte*)bigBuff;  // fall back to static buffer, if necessary
+  if (buf) logbuflen=4096; else buf=(byte*)bigBuff;  // fall back to static buffer, if necessary
   flushToWebClient();
   int chars_read = dataFile.read(buf, logbuflen);
   if (chars_read < 0) {

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -4551,28 +4551,23 @@ uint16_t setPPS(uint8_t pps_index, int16_t value) {
  * *************************************************************** */
 void transmitFile(File dataFile) {
   int logbuflen = (OUTBUF_USEFUL_LEN + OUTBUF_LEN > 1024)?1024:(OUTBUF_USEFUL_LEN + OUTBUF_LEN);
+  byte *buf = (byte*)malloc(4<<10);  // try to use 4 KB buffer, for improved transfer rates
+  if (buf) logbuflen=4<<10; else buf=(byte*)bigBuff;  // fall back to static buffer, if necessary
   flushToWebClient();
-#if !defined(ESP32)
-  int chars_read = dataFile.read(bigBuff , logbuflen);
-#else
-  int chars_read = dataFile.readBytes(bigBuff , logbuflen);
-#endif
+  int chars_read = dataFile.read(buf, logbuflen);
   if (chars_read < 0) {
    printToWebClient(PSTR("Error: Failed to read from SD card - if problem remains after reformatting, card may be incompatible."));
    forcedflushToWebClient();
   }
   while (chars_read == logbuflen) {
-    client.write(bigBuff, logbuflen);
-#if !defined(ESP32)
-    chars_read = dataFile.read(bigBuff , logbuflen);
-#else
-    chars_read = dataFile.readBytes(bigBuff , logbuflen);
-#endif
+    client.write(buf, logbuflen);
+    chars_read = dataFile.read(buf, logbuflen);
 #if defined(ESP32)
     esp_task_wdt_reset();
 #endif
     }
-  if (chars_read > 0) client.write(bigBuff, chars_read);
+  if (chars_read > 0) client.write(buf, chars_read);
+  if (buf != (byte*)bigBuff) free(buf);
 }
 
 #endif


### PR DESCRIPTION
... if available from the heap, otherwise falling back to the existing static (<=) 1 KB buffer
reason: performance improvement (>20% on an esp32 w/o SD card, using wifi)

An equivalent algorithm is already part of my https://github.com/fredlcore/BSB-LAN/pull/542, but only for /Dyyyy-mm-dd,YYYY-MM-DD, as /D and /Dn in that PR use transmitFile() directly (and therefore would also benefit from this PR here!).

The change has been done based on measuring /D times [s] on a datalog.txt of about 970 KB on my system (see above), comparing implementations using the original 1 KB buffer size and the new 4 KB buffer size for the transfer (file reading and data transmission over http):
```
      1 KB   4 KB   gain       
----+------+------+-----
#1    7.09   5.12   28 %
#2    6.92   5.18   25 %
#3    6.86   5.09   26 %
#4    6.80   5.51   19 %
#5    6.79   5.17   24 %
#6    6.80   5.02   26 %
#7    6.79   5.09   25 %
#8    6.76   5.44   20 %
#9    6.79   5.17   24 %
#10   6.80   5.14   24 %
----+------+------+-----
min   6.76   5.02   26 %
max   7.09   5.51   22 %
avg   6.84   5.19   24 %
```
I've created a new PR here, and have not included this in https://github.com/fredlcore/BSB-LAN/pull/542, to allow inclusion of this PR here, even if the other one is not accepted.