### PR TITLE
Disable ESP32 CpuFrequency reduction for about 20 % faster /D

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -7134,8 +7134,9 @@ void setup() {
   SerialOutput->println(F("READY"));
 
 #if defined(ESP32)
-  if (0) // disable the following, because it seems to increase /D times by about 20 %
+#ifndef ESP32_SAVE_D_TIMES_NOT_POWER
   setCpuFrequencyMhz(80);     // reduce speed from 240 MHz to 80 MHz to reduce power consumption by approx. 20% with no significant loss of speed
+#endif
   #ifndef WDT_TIMEOUT
   //set watchdog timeout 120 seconds
     #define WDT_TIMEOUT 120

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -7134,6 +7134,7 @@ void setup() {
   SerialOutput->println(F("READY"));
 
 #if defined(ESP32)
+  if (0) // disable the following, because it seems to increase /D times by about 20 %
   setCpuFrequencyMhz(80);     // reduce speed from 240 MHz to 80 MHz to reduce power consumption by approx. 20% with no significant loss of speed
   #ifndef WDT_TIMEOUT
   //set watchdog timeout 120 seconds

--- a/BSB_LAN/BSB_LAN_config.h.default
+++ b/BSB_LAN/BSB_LAN_config.h.default
@@ -127,6 +127,9 @@ Does: log bus telegrams to file
       push selected values to an MQTT broker*/
 #define LOGGER
 
+// define the following to speed up the system (especially /D... url commands), at the expense of +20% power consumption
+//#define ESP32_SAVE_D_TIMES_NOT_POWER
+
 #define UDP_LOG_PORT 6502 // fixed here, not configurable via web interface
 
 // Use SD card adapter on ESP32-based boards instead of SPIFFS flash-based storage


### PR DESCRIPTION
I've done the following timing test, comparing CPU frequency standard (240 MHz) to reduced to 80 MHz on my system (esp32, no SD card, wifi connection):

Read 1 MB from file and transfer via http, using 4 KB buffers.

The results [s] are as follows:
```
      80 MHz   240 MHz   gain       
----+--------+---------+-----
 #1     4,16      3,69   11 %
 #2     4,79      5,20   -9 %
 #3     4,62      4,60    0 %
 #4     4,14      3,66   12 %
 #5     4,81      2,81   42 %
 #6     3,96      2,99   24 %
 #7     3,62      2,90   20 %
 #8     3,94      2,62   34 %
 #9     4,41      3,04   31 %
#10     3,55      2,99   16 %
----+--------+---------+-----
min     3,55      2,62   26 %
max     4,81      5,20   -8 %
avg     4,20      3,45   18 %
```