### PR TITLE
Bug fix for /Da,b

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -681,7 +681,7 @@ const char datalogIndexTemporaryFileName[] PROGMEM = "/dataidx.tmp";
 // the calendar day just reached (see typedef below), and the size of the actual datalogFile
 // just before that calendar day.
 typedef union {
-  struct { uint16_t year; uint8_t day, month; } elements;  // order is important here!
+  struct { uint8_t day, month; uint16_t year; } elements;  // order is important here!
   uint32_t combined;
 } compactDate_t;
 #if BYTE_ORDER != LITTLE_ENDIAN  // we need this for direct .combined comparisons of two dates


### PR DESCRIPTION
- becomes relevant once year rolls over
- affects /DG, which uses /Da,b
- requires re-building of datalog.idx (e.g. via /D0)!

I am _so_ sorry that I didn't catch this before https://github.com/fredlcore/BSB-LAN/pull/542 was merged!
I thought I had done enough testing then, but as it turns out, I should have used the target platform for that, not some other little-endian system. :/

Before merging, could you please run the following sketch on an Arduino and check if the hex numbers in its output are all in ascending order? (I've done this test for esp32.)
```
typedef union {
  struct { uint8_t day, month; uint16_t year; } elements;  // order is important here!
  uint32_t combined;
} compactDate_t;

void f(int d, int m, int y) {
  char s[99];
  compactDate_t date;
  sprintf(s,"%02d.%02d.%04d => 0x%08X",
          date.elements.day=d,
          date.elements.month=m,
          date.elements.year=y,
          date.combined);
  Serial.println(s);
}

void setup() {
  Serial.begin(115200);
  delay(500);
  f(31,12,1999);
  f( 1, 1,2000);
  f(31,12,2022);
  f( 1, 1,2023);
  f(11,12,2047);
  f( 1, 2,2048);
  f(31,12,9999);
}

void loop() {
}
```
If you wish, I can provide a script to re-build datalog.idx offline.
I've used that myself to avoid /D0 after applying the fix described here, as follows:
1. download /D (which doesn't use datalog.idx and therefore isn't affected by the bug fixed here: `wget -qOdatalog.txt bsb-lan/D`)
2. re-build datalog.idx from datalog.txt (using my script)
3. replace the file system on bsb-lan with one containing datalog.txt with the fixed datalog.idx (Arduino IDE: Tools -> ESP32 Sketch Data Upload)