### PR TITLE
Moving ENUM15000_02_TEXT definition from locaization file to BSB_LAN_…

### DIFF
--- a/BSB_LAN/BSB_LAN_defs.h
+++ b/BSB_LAN/BSB_LAN_defs.h
@@ -1116,6 +1116,7 @@ const char ENUM701[] PROGMEM_LATEST = {
 };
 
 // PPS Betriebsart
+#define ENUM15000_02_TEXT MENU_TEXT_OFF
 const char ENUM15000[] PROGMEM_LATEST = {
 "\x00 " ENUM15000_00_TEXT "\0"
 "\x01 " ENUM15000_01_TEXT "\0"

--- a/BSB_LAN/localization/LANG_DE.h
+++ b/BSB_LAN/localization/LANG_DE.h
@@ -3376,7 +3376,7 @@
 #define ENUM14088_00_TEXT "Kein mit Maximalauswahl"
 #define ENUM15000_00_TEXT "Automatisch"
 #define ENUM15000_01_TEXT "Manuell"
-#define ENUM15000_02_TEXT MENU_TEXT_OFF
+//#define ENUM15000_02_TEXT MENU_TEXT_OFF. This definition is moved to BSB_LAN/BSB_LAN_defs.h file
 #define ENUM15044_00_02_TEXT "Auto-Mode: aus"
 #define ENUM15044_02_02_TEXT "Auto-Mode: an"
 #define ENUM15044_00_08_TEXT "Pumpe an"


### PR DESCRIPTION
…custom_defs.h.default

Because this definition is cause trouble when conversion from .h to .js is called.