### PR TITLE
Re-enable use of Arduino 1.8.19 for ESP32

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -537,6 +537,7 @@
 
 // Forward declarations
 #if defined(ESP32)
+#include <Arduino.h> // for definition of the data types uint64_t and String
 uint64_t usedBytes();
 uint64_t totalBytes();
 String scanAndConnectToStrongestNetwork();


### PR DESCRIPTION
With https://github.com/fredlcore/BSB-LAN/commit/0d59fc1f9ecd51dc611259d1fb66d4427615d1c3 compiling for ESP32 using Arduino IDE 1.8.19 is not possible anymore because the types `uint64_t` and `String` need to be defined.