### PR TITLE
Wait USB Serial connection to establish before sending debug

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -7320,6 +7320,7 @@ void setup() {
   pinMode(EEPROM_ERASING_GND_PIN, OUTPUT);
 #endif
 
+  delay(1000); // wait USB serial connection to establish
   SerialOutput->println(F("READY"));
 
 #if defined(__arm__)


### PR DESCRIPTION
On my device, on power on, the esp starts faster than the usb-ttl chip.
It's start outputting useful init debug info while the serial connection is not ready yet.
It needs between 500ms and 1sec to initialize. I added a delay in the setup before sending the first message. As this is only at power on, I don't think such delay has any drawback.