### PR TITLE
Change some GUI strings to address SD card vs. flash memory ambiguity

### DIFF
--- a/BSB_LAN/BSB_LAN_EEPROMconfig.h
+++ b/BSB_LAN/BSB_LAN_EEPROMconfig.h
@@ -176,10 +176,10 @@ const configuration_struct config[]={
   {CF_CRC32,            0, CCAT_GENERAL,  CPI_NOTHING,   CDT_VOID,           OPT_FL_BASIC|OPT_FL_ADVANCED, NULL, sizeof(uint32_t)},
   {CF_WRITEMODE,        2, CCAT_GENERAL,  CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_WRITEMODE_TXT, sizeof(programWriteMode)},
   {CF_CHECKUPDATE,      3, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_CHECKUPDATE_TXT, sizeof(enable_version_check)}, //immediately apply
-  #ifdef ESP32
+#ifdef ESP32
   {CF_OTA_UPDATE,       6, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_OTA_UPDATE_TXT, sizeof(enable_ota_update)}, //immediately apply
   {CF_ESP32_ENERGY_SAVE,11,CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_ENERGY_SAVE_TXT, sizeof(esp32_save_energy)}, //need reboot
-  #endif
+#endif
   {CF_WEBSERVER,        2, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_WEBSERVER_TXT, sizeof(webserver)},
   {CF_BUSTYPE,          1, CCAT_BUS,      CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_BUSTYPE_TXT, sizeof(bus_type)},//need handler
   {CF_PPS_MODE,         1, CCAT_BUS,      CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_PPS_WRITE_TXT, sizeof(pps_write)},//need handler
@@ -206,9 +206,9 @@ const configuration_struct config[]={
   {CF_PASSKEY,          2, CCAT_IPV4,     CPI_TEXT,      CDT_STRING,         OPT_FL_ADVANCED, CF_PASSKEY_TXT, sizeof(PASSKEY)},//immediately apply
   {CF_TRUSTEDIPADDRESS, 2, CCAT_IPV4,     CPI_TEXT,      CDT_IPV4,           OPT_FL_ADVANCED, CF_TRUSTEDIPADDRESS_TXT, sizeof(trusted_ip_addr)}, //immediately apply
   {CF_TRUSTEDIPADDRESS2,2, CCAT_IPV4,     CPI_TEXT,      CDT_IPV4,           OPT_FL_ADVANCED, CF_TRUSTEDIPADDRESS_TXT, sizeof(trusted_ip_addr2)},//immediately apply
-  #ifdef ESP32
+#ifdef ESP32
   {CF_LOG_DEST,         12,CCAT_LOGGING,  CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOG_DEST_TXT, sizeof(LogDestination)}, //need handler
-  #endif
+#endif
   {CF_LOGMODE,          10,CCAT_LOGGING,  CPI_CHECKBOXES,CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOGMODE_TXT, sizeof(LoggingMode)}, //immediately apply
   {CF_LOGCURRINTERVAL,  1, CCAT_LOGGING,  CPI_TEXT,      CDT_UINT32,         OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOGCURRINTERVAL_TXT, sizeof(log_interval)},//immediately apply
   {CF_CURRVALUESLIST,   1, CCAT_LOGGING,  CPI_TEXT,      CDT_PROGNRLIST,     OPT_FL_BASIC|OPT_FL_ADVANCED, CF_PROGLIST_TXT, sizeof(log_parameters)},//immediately apply

--- a/BSB_LAN/BSB_LAN_EEPROMconfig.h
+++ b/BSB_LAN/BSB_LAN_EEPROMconfig.h
@@ -135,22 +135,22 @@ typedef enum {
 
 
 typedef struct {
-	uint8_t id;		// a unique identifier that can be used for the input tag name (cf_params)
-  uint8_t version; //config version which can manage this parameter
-  uint8_t category;	// for grouping configuration options (cdt_params)
-  uint8_t input_type;	// input type (text, dropdown etc.) 0 - none 1 - text field, 2 - switch, 3 - dropdown, 4 - bitwise (checkboxes)
-  uint8_t var_type;	// variable type (string, integer, float, boolean etc.), could maybe be derived from input_type or vice versa
-  uint8_t flags; // options flags: 1 - basic option, 2 - advanced option
-  const char* desc;	// pointer to text to be displayed for option - is text length necessary if we just read until NULL?
-  uint16_t size; //data length in EEPROM
+  uint8_t id;          // a unique identifier that can be used for the input tag name (cf_params)
+  uint8_t version;     // config version which can manage this parameter
+  uint8_t category;    // for grouping configuration options (cdt_params)
+  uint8_t input_type;  // input type (text, dropdown etc.) 0 - none 1 - text field, 2 - switch, 3 - dropdown, 4 - bitwise (checkboxes)
+  uint8_t var_type;    // variable type (string, integer, float, boolean etc.), could maybe be derived from input_type or vice versa
+  uint8_t flags;       // options flags: 1 - basic option, 2 - advanced option
+  const char* desc;    // pointer to text to be displayed for option - is text length necessary if we just read until NULL?
+  uint16_t size;       // data length in EEPROM
 } configuration_struct;
 
 #define OPT_FL_BASIC 1
 #define OPT_FL_ADVANCED 2
 
 typedef struct {
-	uint8_t id;		// a unique identifier of param Category
-  const char* desc;	// pointer to text to be displayed for category of option - is text length necessary if we just read until NULL?
+  uint8_t id;          // a unique identifier of param Category
+  const char* desc;    // pointer to text to be displayed for category of option - is text length necessary if we just read until NULL?
 } category_list_struct;
 
 const category_list_struct catalist[]={
@@ -179,6 +179,7 @@ const configuration_struct config[]={
   #ifdef ESP32
   {CF_OTA_UPDATE,       6, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_OTA_UPDATE_TXT, sizeof(enable_ota_update)}, //immediately apply
   {CF_ESP32_ENERGY_SAVE,11,CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_ENERGY_SAVE_TXT, sizeof(esp32_save_energy)}, //need reboot
+  {CF_LOG_DEST,         12,CCAT_GENERAL,  CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOG_DEST_TXT, sizeof(LogDestination)}, //need handler
   #endif
   {CF_WEBSERVER,        2, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_WEBSERVER_TXT, sizeof(webserver)},
   {CF_BUSTYPE,          1, CCAT_BUS,      CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_BUSTYPE_TXT, sizeof(bus_type)},//need handler
@@ -206,9 +207,6 @@ const configuration_struct config[]={
   {CF_PASSKEY,          2, CCAT_IPV4,     CPI_TEXT,      CDT_STRING,         OPT_FL_ADVANCED, CF_PASSKEY_TXT, sizeof(PASSKEY)},//immediately apply
   {CF_TRUSTEDIPADDRESS, 2, CCAT_IPV4,     CPI_TEXT,      CDT_IPV4,           OPT_FL_ADVANCED, CF_TRUSTEDIPADDRESS_TXT, sizeof(trusted_ip_addr)}, //immediately apply
   {CF_TRUSTEDIPADDRESS2,2, CCAT_IPV4,     CPI_TEXT,      CDT_IPV4,           OPT_FL_ADVANCED, CF_TRUSTEDIPADDRESS_TXT, sizeof(trusted_ip_addr2)},//immediately apply
-#ifdef ESP32
-  {CF_LOG_DEST,         12,CCAT_LOGGING,  CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOG_DEST_TXT, sizeof(LogDestination)}, //need handler
-#endif
   {CF_LOGMODE,          10,CCAT_LOGGING,  CPI_CHECKBOXES,CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOGMODE_TXT, sizeof(LoggingMode)}, //immediately apply
   {CF_LOGCURRINTERVAL,  1, CCAT_LOGGING,  CPI_TEXT,      CDT_UINT32,         OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOGCURRINTERVAL_TXT, sizeof(log_interval)},//immediately apply
   {CF_CURRVALUESLIST,   1, CCAT_LOGGING,  CPI_TEXT,      CDT_PROGNRLIST,     OPT_FL_BASIC|OPT_FL_ADVANCED, CF_PROGLIST_TXT, sizeof(log_parameters)},//immediately apply

--- a/BSB_LAN/BSB_LAN_EEPROMconfig.h
+++ b/BSB_LAN/BSB_LAN_EEPROMconfig.h
@@ -179,7 +179,6 @@ const configuration_struct config[]={
   #ifdef ESP32
   {CF_OTA_UPDATE,       6, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_OTA_UPDATE_TXT, sizeof(enable_ota_update)}, //immediately apply
   {CF_ESP32_ENERGY_SAVE,11,CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_ENERGY_SAVE_TXT, sizeof(esp32_save_energy)}, //need reboot
-  {CF_LOG_DEST,         12,CCAT_GENERAL,  CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOG_DEST_TXT, sizeof(LogDestination)}, //need handler
   #endif
   {CF_WEBSERVER,        2, CCAT_GENERAL,  CPI_SWITCH,    CDT_BYTE,           OPT_FL_ADVANCED, CF_WEBSERVER_TXT, sizeof(webserver)},
   {CF_BUSTYPE,          1, CCAT_BUS,      CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_BUSTYPE_TXT, sizeof(bus_type)},//need handler
@@ -207,6 +206,9 @@ const configuration_struct config[]={
   {CF_PASSKEY,          2, CCAT_IPV4,     CPI_TEXT,      CDT_STRING,         OPT_FL_ADVANCED, CF_PASSKEY_TXT, sizeof(PASSKEY)},//immediately apply
   {CF_TRUSTEDIPADDRESS, 2, CCAT_IPV4,     CPI_TEXT,      CDT_IPV4,           OPT_FL_ADVANCED, CF_TRUSTEDIPADDRESS_TXT, sizeof(trusted_ip_addr)}, //immediately apply
   {CF_TRUSTEDIPADDRESS2,2, CCAT_IPV4,     CPI_TEXT,      CDT_IPV4,           OPT_FL_ADVANCED, CF_TRUSTEDIPADDRESS_TXT, sizeof(trusted_ip_addr2)},//immediately apply
+  #ifdef ESP32
+  {CF_LOG_DEST,         12,CCAT_LOGGING,  CPI_DROPDOWN,  CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOG_DEST_TXT, sizeof(LogDestination)}, //need handler
+  #endif
   {CF_LOGMODE,          10,CCAT_LOGGING,  CPI_CHECKBOXES,CDT_BYTE,           OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOGMODE_TXT, sizeof(LoggingMode)}, //immediately apply
   {CF_LOGCURRINTERVAL,  1, CCAT_LOGGING,  CPI_TEXT,      CDT_UINT32,         OPT_FL_BASIC|OPT_FL_ADVANCED, CF_LOGCURRINTERVAL_TXT, sizeof(log_interval)},//immediately apply
   {CF_CURRVALUESLIST,   1, CCAT_LOGGING,  CPI_TEXT,      CDT_PROGNRLIST,     OPT_FL_BASIC|OPT_FL_ADVANCED, CF_PROGLIST_TXT, sizeof(log_parameters)},//immediately apply

--- a/BSB_LAN/localization/LANG_DE.h
+++ b/BSB_LAN/localization/LANG_DE.h
@@ -205,7 +205,7 @@
 #define MENU_LINK_FAQ "https://1coderookie.github.io/BSB-LPB-LAN/kap15.html"
 #define MENU_LINK_URL "https://1coderookie.github.io/BSB-LPB-LAN/kap05.html#51-url-befehle"
 #define MENU_TEXT_LOT "Telegramme loggen"
-#define MENU_TEXT_FSP "Freier Speicher auf SD Karte"
+#define MENU_TEXT_FSP "Freier Speicher im Dateisystem"
 
 #define STR_24A_TEXT "24h Durchschnittswert"
 
@@ -232,7 +232,7 @@
 #define CF_WWWPORT_TEXT "TCP Port"
 #define CF_WIFI_SSID_TEXT "WLAN SSID"
 #define CF_WIFI_PASSWORD_TEXT "WLAN Passwort"
-#define CF_WEBSERVER_TEXT "Webserver SD-Karte / Flash-Speicher"
+#define CF_WEBSERVER_TEXT "Webserver Dateisystem"
 #define CF_PASSKEY_TEXT "URL Passkey"
 #define CF_BASICAUTH_TEXT "HTTP-Authentifizierung"
 #define CF_PINS_TEXT "Pins"
@@ -254,7 +254,7 @@
 #define CF_RX_PIN_TEXT "RX Pin Nummer"
 #define CF_TX_PIN_TEXT "TX Pin Nummer"
 #define CF_CONFIG_LEVEL_TEXT "Erweiterte Einstellungen anzeigen"
-#define CF_ENERGY_SAVE_TEXT "ESP32 Energiesparmodus"
+#define CF_ENERGY_SAVE_TEXT "Energiesparmodus"
 
 #define CAT_GENERAL_TEXT "Generell"
 #define CAT_IPV4_TEXT "Netzwerk"

--- a/BSB_LAN/localization/LANG_EN.h
+++ b/BSB_LAN/localization/LANG_EN.h
@@ -162,7 +162,7 @@
 #define MENU_TEXT_LGI "New logging interval"
 #define MENU_TEXT_LGN "New logging parameters"
 #define MENU_TEXT_LOT "Log of telegrams"
-#define MENU_TEXT_FSP "Free space on SD card"
+#define MENU_TEXT_FSP "Free space in file system"
 
 #define STR_24A_TEXT "24h average"
 
@@ -188,7 +188,7 @@
 #define CF_TRUSTEDIPADDRESS_TEXT "Trusted IP address"
 #define CF_MASK_TEXT "Subnet"
 #define CF_WIFI_PASSWORD_TEXT "WLAN password"
-#define CF_WEBSERVER_TEXT "Webserver SD card / flash memory"
+#define CF_WEBSERVER_TEXT "Webserver file system"
 #define CF_BASICAUTH_TEXT "HTTP authentification"
 #define CF_ONEWIREBUS_DEVICES_TEXT "Devices"
 #define CF_PINS_TEXT "Pins"
@@ -202,7 +202,7 @@
 #define CF_LOGMODE_TEXT "Logging mode"
 #define CF_CHECKUPDATE_TEXT "Check for updates"
 #define CF_SHOW_UNKNOWN_TEXT "Display unknown parameters"
-#define CF_ENERGY_SAVE_TEXT "ESP32 energy saving"
+#define CF_ENERGY_SAVE_TEXT "Energy saving"
 #define CF_LOG_DEST_TEXT "Storage device"
 
 #define ENUM_LOG_DEST_00_TEXT "SD card"


### PR DESCRIPTION
With reference to https://github.com/fredlcore/BSB-LAN/issues/632#issuecomment-1999089017

Moved storage location config to general section, as it applies for both logging and webserver file system.
**Please note: I don't know if this requires additional measures to address possible shifts in EEPROM storage locations!**

Changed some GUI strings to address SD card vs. flash memory ambiguity.

Removed "ESP32" from GUI string for energy saving, as other ESP32 only strings don't have that prefix either (OTA, SD/flash).

Adjusted whitespace in one code area, so that comments properly align regardless of tab width setting.