### PR TITLE
Add BSB-LAN watermark to /DG chart

### DIFF
--- a/BSB_LAN/html_strings.h
+++ b/BSB_LAN/html_strings.h
@@ -87,6 +87,8 @@ const char graph_html[] =
     ".c3-tooltip{opacity:0.7;background-color:#eee}" NEWLINE
     "th{background-color:#ccc}" NEWLINE
     ".value{text-align:right}" NEWLINE
+    // add BSB-LAN watermark (remove the following line if you don't like it):
+    ".c3:before{position:absolute;z-index:-1;width:100%;height:100%;content:'';opacity:.02;background:url('favicon.svg')no-repeat center}" NEWLINE
   "</style>" NEWLINE
   "<script src='" D3_LIBRARY_PATH "'></script>" NEWLINE
   "<script src='" C3_LIBRARY_PATH "'></script>" NEWLINE


### PR DESCRIPTION
Tested with Firefox (Ubuntu), Chromium (Ubuntu), Chrome (Android), Silk (Android), Edge (Win11), Safari (Mac)
![grafik](https://github.com/fredlcore/BSB-LAN/assets/105788188/d80a392f-3746-4281-9a19-28ab0c9a567f)
(It would have been much easier if the favicon was a light enough color right away: `.c3{background:url('favicon.svg')no-repeat center}`.)