### PR TITLE
Simplify code in BSB-LAN_datalog-viewer.html

### DIFF
--- a/BSB_LAN/scripts/BSB-LAN_datalog-viewer.html
+++ b/BSB_LAN/scripts/BSB-LAN_datalog-viewer.html
@@ -29,9 +29,8 @@
       .c3-tooltip{opacity:0.7;background-color:#eee}
       .c3-tooltip th{background-color:#ccc}
       .c3-tooltip .value{text-align:right}
-      .c3:before{position:absolute;z-index:-1;width:100%;height:100%;content:'';
-        opacity:.02;background:no-repeat center url("data:image/svg+xml,\
-          <svg class='logo' viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'>\
+      .c3{background:no-repeat center url("data:image/svg+xml,\
+          <svg fill='%23fafafa' viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'>\
            <path id='b' d='m98 47-63 1c-6 0-12 4-11 11v88c1 5 3 10 10 11l79-1c25-1\
             24-53 4-61 11-5 18-49-19-49zM48 72h52c1 10-2 18-11 19l-38 1v22l43-1c14\
             0 14 11 14 20H48Z'/>\


### PR DESCRIPTION
Contrary to the BSB-LAN executable, we don't use an existing black svg here, but are creating our own one. Therefore we don't have to go through hoops to achieve opacity; we can just render the svg lighter.

Sorry for not thinking of this while https://github.com/fredlcore/BSB-LAN/pull/647 was still open.
Feel free to ignore this change proposal and just close the PR.