### PR TITLE
/DG: added rescaling and subchart on zooming

### DIFF
--- a/BSB_LAN/html_strings.h
+++ b/BSB_LAN/html_strings.h
@@ -146,7 +146,11 @@ const char graph_html[] =
         "}," NEWLINE
         "point:{show:false}," NEWLINE
         "axis:{x:{type:'timeseries',tick:{count:3,format:e}}}," NEWLINE
-        "zoom:{enabled:true}," NEWLINE
+        "zoom:{" NEWLINE
+          "enabled:true," NEWLINE
+          "rescale:true," NEWLINE
+          "onzoomstart:function(){c.subchart.show()}" NEWLINE
+        "}," NEWLINE
         "size:{height:window.innerHeight-20}," NEWLINE
         "onresize:function(){c.resize({height:window.innerHeight-20})}" NEWLINE
       "})" NEWLINE

--- a/BSB_LAN/scripts/BSB-LAN_datalog-viewer.html
+++ b/BSB_LAN/scripts/BSB-LAN_datalog-viewer.html
@@ -94,7 +94,11 @@
           },
           point:{show:false},
           axis:{x:{type:'timeseries',tick:{count:3,format:f}}},
-          zoom:{enabled:true},
+          zoom:{
+            enabled:true,
+            rescale:true,
+            onzoomstart:function(){c.subchart.show()}
+          },
           size:{height:window.innerHeight-40},
           onresize:function(){c.resize({height:window.innerHeight-40})}
         });


### PR DESCRIPTION
notes:
the subchart only becomes visible when zooming in on the chart
the subchart's gray area can be moved to move the zoom window
helpful subchart side effect: when zoomed in, de-/selecting curves doesn't zoom out, as it does w/o a subchart
to get rid of the subchart: reload /DG

before the code change:
![Bildschirmfoto vom 2024-09-04 07-13-56](https://github.com/user-attachments/assets/765fd87c-7cd7-494d-9d4b-fe71729111d6)

with the code change:
![Bildschirmfoto vom 2024-09-04 07-13-44](https://github.com/user-attachments/assets/47c2aba6-61bf-4613-8cd8-fdee5e4f118e)
