### PR TITLE
(Hopefully) fix the MQTT disconnections happening all the time

### DIFF
--- a/BSB_LAN/include/mqtt_handler.h
+++ b/BSB_LAN/include/mqtt_handler.h
@@ -196,6 +196,8 @@ bool mqtt_connect() {
     mqtt_client= new ComClient();
     MQTTPubSubClient = new PubSubClient(mqtt_client[0]);
     MQTTPubSubClient->setBufferSize(2048);
+    MQTTPubSubClient->setKeepAlive(30);
+    MQTTPubSubClient->setSocketTimeout(120);
     mqtt_reconnect_timer = 0;
     first_connect = true;
   }

--- a/BSB_LAN/src/PubSubClient/src/PubSubClient.cpp
+++ b/BSB_LAN/src/PubSubClient/src/PubSubClient.cpp
@@ -253,6 +253,7 @@ boolean PubSubClient::connect(const char *id, const char *user, const char *pass
             write(MQTTCONNECT,this->buffer,length-MQTT_MAX_HEADER_SIZE);
 
             lastInActivity = lastOutActivity = millis();
+            pingOutstanding = false;
 
             while (!_client->available()) {
                 unsigned long t = millis();
@@ -374,6 +375,7 @@ boolean PubSubClient::loop() {
             if (pingOutstanding) {
                 this->_state = MQTT_CONNECTION_TIMEOUT;
                 _client->stop();
+                pingOutstanding = false;
                 return false;
             } else {
                 this->buffer[0] = MQTTPINGREQ;
@@ -665,6 +667,7 @@ void PubSubClient::disconnect() {
     _client->flush();
     _client->stop();
     lastInActivity = lastOutActivity = millis();
+    pingOutstanding = false;
 }
 
 uint16_t PubSubClient::writeString(const char* string, uint8_t* buf, uint16_t pos) {


### PR DESCRIPTION
This PR adds better values for keep alives and socket timeouts:

```C
    MQTTPubSubClient->setKeepAlive(30);
    MQTTPubSubClient->setSocketTimeout(120);
```

The keep alive tells the client to send a packet to the broker to tell it "yes I am there". If the broker does not get keep alive packets often enough, it will disconnect.

Actually the socket timeout identical to keep alive looks strange to me. I raised it to 120 seconds. This would mean that if the server does not send a keep alive to the client in time, the client will kill the connection. The default keep alive value in Mosquitto is 60 secs, minimum configurable is 5s:

MAN page of mosquitto:
>        keepalive_interval seconds
>           Set the number of seconds after which the bridge should send a ping if no other traffic has occurred. Defaults to 60. A minimum value of 5 seconds is allowed.

Basically the socket timeout needs `>>` keep-alives (thats what my knowledge about similar protocols tell me, I am devloping large network protocols with Elasticsearch/Apache Lucene/Apache Solr so that's my daily business).

It also looks like one of the many keepalive bugs in the (now unmaintained) PubSubClient:
- https://github.com/knolleary/pubsubclient/issues/795
- https://github.com/knolleary/pubsubclient/issues/829
- https://github.com/knolleary/pubsubclient/issues/810

Those issues seem to be fixed by: https://github.com/knolleary/pubsubclient/pull/802

As you have the code of PubSubClient 2.8 included, I also added the missing line in it.

To explain why it happens:
- when the pubsub client (re-)connects to the MQTT broker, it forgets to reset the "pingOutstanding" variable to false. It sometimes does it (depending what the server sends), but generally the state is undefined. 
- When BSB-LAN starts up, it seems to connect 2 times to MQTT (it looks like it reconnects after applying some config from EEPROM). Nevertheless, if it is in the state "pingOutstanding" while disconnecting for first time it stays with that. When entering the main loop it waits for the ping and/or other messages and disconnects if theres no activity withing 15 secs on wire. It does not exit that state, because the server won't send a ping response if no ping was requested before. This effectively makes the keep alive broken, as itself won't send any new pings anymore, so on longer latencies ther server or client diconnects.

The fix is to initialize `pingOutstanding=false` on connection.