### PR TITLE
Update pubsubclient to v2.10 by thingsboard

### DIFF
--- a/BSB_LAN/include/mqtt_handler.h
+++ b/BSB_LAN/include/mqtt_handler.h
@@ -196,8 +196,7 @@ bool mqtt_connect() {
     mqtt_client= new ComClient();
     MQTTPubSubClient = new PubSubClient(mqtt_client[0]);
     MQTTPubSubClient->setBufferSize(2048);
-    MQTTPubSubClient->setKeepAlive(30);
-    MQTTPubSubClient->setSocketTimeout(120);
+    MQTTPubSubClient->setKeepAlive(90); // raise to higher value so broker does not disconnect on latency
     mqtt_reconnect_timer = 0;
     first_connect = true;
   }
@@ -225,6 +224,7 @@ bool mqtt_connect() {
     MQTTPubSubClient->setServer(mqtt_host, mqtt_port);
     printFmtToDebug("Client ID: %s\r\n", mqtt_get_client_id());
     printFmtToDebug("Will topic: %s\r\n", mqtt_get_will_topic());
+    MQTTPubSubClient->setSocketTimeout(MQTT_SOCKET_TIMEOUT); // reset to default
     MQTTPubSubClient->connect(mqtt_get_client_id(), MQTTUser, MQTTPass, mqtt_get_will_topic(), 1, true, "offline");
     if (!MQTTPubSubClient->connected()) {
       printlnToDebug("Failed to connect to MQTT broker, retrying...");
@@ -237,7 +237,7 @@ bool mqtt_connect() {
       strcat(tempTopic, "/#");
       MQTTPubSubClient->subscribe(tempTopic, 1);   //Luposoft: set the topic listen to
       printFmtToDebug("Subscribed to topic '%s'\r\n", tempTopic);
-      MQTTPubSubClient->setKeepAlive(120);       //Luposoft: just for savety
+      MQTTPubSubClient->setSocketTimeout(120); // uschindler: set socket timeout to higher value after connection
       MQTTPubSubClient->setCallback(mqtt_callback);  //Luposoft: set to function is called when incoming message
       MQTTPubSubClient->publish(mqtt_get_will_topic(), "online", true);
       printFmtToDebug("Published status 'online' to topic '%s'\r\n", mqtt_get_will_topic());

--- a/BSB_LAN/src/PubSubClient/CHANGES.txt
+++ b/BSB_LAN/src/PubSubClient/CHANGES.txt
@@ -1,3 +1,5 @@
+2.9
+   * Add ability to use function for callback not just for ESP boards
 2.8
    * Add setBufferSize() to override MQTT_MAX_PACKET_SIZE
    * Add setKeepAlive() to override MQTT_KEEPALIVE

--- a/BSB_LAN/src/PubSubClient/README.md
+++ b/BSB_LAN/src/PubSubClient/README.md
@@ -1,3 +1,11 @@
+## ThingsBoard note
+
+This is a fork of the main repository, which was last updated in 2020.  
+Since we have an SDK based on this client, we decided to continue with this repository.  
+We also believe that this library provides a lot of opportunities for people who want to build their own IoT devices.  
+As with our other open source repositories, we appreciate every contribution to this library.  
+
+
 # Arduino Client for MQTT
 
 This library provides a client for doing simple publish/subscribe messaging with

--- a/BSB_LAN/src/PubSubClient/library.json
+++ b/BSB_LAN/src/PubSubClient/library.json
@@ -1,18 +1,19 @@
 {
-    "name": "PubSubClient",
-    "keywords": "ethernet, mqtt, m2m, iot",
+    "name": "TBPubSubClient",
+    "keywords": "ethernet, mqtt, m2m, iot, thingsboard, messages",
     "description": "A client library for MQTT messaging. MQTT is a lightweight messaging protocol ideal for small devices. This library allows you to send and receive MQTT messages. It supports the latest MQTT 3.1.1 protocol and can be configured to use the older MQTT 3.1 if needed. It supports all Arduino Ethernet Client compatible hardware, including the Intel Galileo/Edison, ESP8266 and TI CC3000.",
     "repository": {
         "type": "git",
-        "url": "https://github.com/knolleary/pubsubclient.git"
+        "url": "https://github.com/thingsboard/pubsubclient.git"
     },
-    "version": "2.8",
+    "version": "2.10.0",
     "exclude": "tests",
     "examples": "examples/*/*.ino",
     "frameworks": "arduino",
     "platforms": [
         "atmelavr",
         "espressif8266",
-        "espressif32"
+        "espressif32",
+        "rp2040"
     ]
 }

--- a/BSB_LAN/src/PubSubClient/library.properties
+++ b/BSB_LAN/src/PubSubClient/library.properties
@@ -1,7 +1,7 @@
-name=PubSubClient
-version=2.8
-author=Nick O'Leary <nick.oleary@gmail.com>
-maintainer=Nick O'Leary <nick.oleary@gmail.com>
+name=TBPubSubClient
+version=2.10.0
+author=ThingsBoard <info@thingsboard.io>
+maintainer=ThingsBoard Team
 sentence=A client library for MQTT messaging.
 paragraph=MQTT is a lightweight messaging protocol ideal for small devices. This library allows you to send and receive MQTT messages. It supports the latest MQTT 3.1.1 protocol and can be configured to use the older MQTT 3.1 if needed. It supports all Arduino Ethernet Client compatible hardware, including the Intel Galileo/Edison, ESP8266 and TI CC3000.
 category=Communication

--- a/BSB_LAN/src/PubSubClient/src/PubSubClient.h
+++ b/BSB_LAN/src/PubSubClient/src/PubSubClient.h
@@ -76,19 +76,24 @@
 // Maximum size of fixed header and variable length size header
 #define MQTT_MAX_HEADER_SIZE 5
 
-#if defined(ESP8266) || defined(ESP32)
-#include <functional>
-#define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, unsigned int)> callback
-#else
-#define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, unsigned int)
-#endif
+#  ifdef __has_include
+#    if __has_include(<functional>)
+#      include <functional>
+#      define MQTT_CALLBACK_SIGNATURE std::function<void(char*, uint8_t*, size_t)> callback
+#    else
+#      define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, size_t)
+#    endif
+#  else
+#    define MQTT_CALLBACK_SIGNATURE void (*callback)(char*, uint8_t*, size_t)
+#  endif
 
 #define CHECK_STRING_LENGTH(l,s) if (l+2+strnlen(s, this->bufferSize) > this->bufferSize) {_client->stop();return false;}
 
 class PubSubClient : public Print {
 private:
    Client* _client;
-   uint8_t* buffer;
+   uint8_t* receive_buffer;
+   uint8_t* send_buffer;
    uint16_t bufferSize;
    uint16_t keepAlive;
    uint16_t socketTimeout;
@@ -128,7 +133,7 @@ public:
    PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client);
    PubSubClient(const char*, uint16_t, MQTT_CALLBACK_SIGNATURE,Client& client, Stream&);
 
-   virtual ~PubSubClient();
+   ~PubSubClient();
 
    PubSubClient& setServer(IPAddress ip, uint16_t port);
    PubSubClient& setServer(uint8_t * ip, uint16_t port);
@@ -150,10 +155,10 @@ public:
    void disconnect();
    boolean publish(const char* topic, const char* payload);
    boolean publish(const char* topic, const char* payload, boolean retained);
-   boolean publish(const char* topic, const uint8_t * payload, unsigned int plength);
-   boolean publish(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
+   boolean publish(const char* topic, const uint8_t * payload, size_t plength);
+   boolean publish(const char* topic, const uint8_t * payload, size_t plength, boolean retained);
    boolean publish_P(const char* topic, const char* payload, boolean retained);
-   boolean publish_P(const char* topic, const uint8_t * payload, unsigned int plength, boolean retained);
+   boolean publish_P(const char* topic, const uint8_t * payload, size_t plength, boolean retained);
    // Start to publish a message.
    // This API:
    //   beginPublish(...)
@@ -162,7 +167,7 @@ public:
    // Allows for arbitrarily large payloads to be sent without them having to be copied into
    // a new buffer and held in memory at one time
    // Returns 1 if the message was started successfully, 0 if there was an error
-   boolean beginPublish(const char* topic, unsigned int plength, boolean retained);
+   boolean beginPublish(const char* topic, size_t plength, boolean retained);
    // Finish off this publish message (started with beginPublish)
    // Returns 1 if the packet was sent successfully, 0 if there was an error
    int endPublish();
@@ -174,11 +179,11 @@ public:
    boolean subscribe(const char* topic);
    boolean subscribe(const char* topic, uint8_t qos);
    boolean unsubscribe(const char* topic);
+   boolean loop_read();
    boolean loop();
    boolean connected();
    int state();
 
 };
-
 
 #endif


### PR DESCRIPTION
A discussed in #682, this PR updates the pubsubclient for MQTT support to 2.10.

Initially the update did not work, because unfortunately the latest version 2.10 introduced a copypaste bug when a password is given for the MQTT client. The password was appended to wrong buffer.

Apropos buffers: The new version uses a separate buffer for receiving values and one for publishing to topics, so the client does not break if you publish new topics from the callback. The big issue with current client (next to the still existing keep-alive) code is that the main receive loop() uses the same buffer than the publishing code, which may lead to problems when you write to the MQTT from the callback - which BSB-LAN is doing (we publish our status from the callback).

I also now understood the code around the keepalive:
- the keepalive should be larger, the old code set it to 120 seconds. I lowered it to 90s. The keepalive is sent to server on connection (and because of this it has to be initialized early). This was not correct in previous code. The keep alive MUST be set before connecting
- the socket timeout should be small before connecting, as the value of 120s (that @fredlcore committed recently on my request) causes the connection to fail after 120s when the server is not reachable or the handshake fails. As this part should go fast and the hanging connection should not stop BSB-LAN from progressing, I initialize the socket timeout explicitely to the default value BEFORE connection
- after connection established, the socket timeout is raised to 120s. This makes sure that the pubsubclient is waiting long enough for broker responses (e.g. the ping). If the MQTT connection fails later, BSB-LAN will block for 120 seconds, but will recover soon after disconnecting and reconnecting. I think this is acceptable.

The keepalive code still has the initialization problem as mentioned before.

For all issues in version 2.10 of the pubsubclient library I will open a PR on their repository tomorrow. Maybe they release 2.11 soon. The password issue is the biggest problem (copypaste error where send_buffer was used instead of receive_buffer) is a serious bug! The keepalive handling works better now.

I marked all lines of code that I patched in the current version with a comment. When you update to 2.11 or later, the lines are hopefully obsolete.

I have this new code now running on my box. Observations:
- No multiple connections on booting BSB-LAN. Previously the code often reconnected initially, which was an issue with the single buffer for receive and publishing.

I am at moment making the stress test. If all works well tomorrow morning, feel free to commit this.