### PR TITLE
Fix "use after free" in setup of hostname for MQTT connection

### DIFF
--- a/BSB_LAN/include/mqtt_handler.h
+++ b/BSB_LAN/include/mqtt_handler.h
@@ -202,7 +202,7 @@ bool mqtt_connect() {
       return false;
     }
 
-    char* tempstr = (char*)malloc(sizeof(mqtt_broker_addr));  // make a copy of mqtt_broker_addr for destructive strtok operation
+    char tempstr[sizeof(mqtt_broker_addr)];  // make a copy of mqtt_broker_addr for destructive strtok operation
     strcpy(tempstr, mqtt_broker_addr);
     uint16_t mqtt_port = 1883; 
     char* mqtt_host = strtok(tempstr,":");  // hostname is before an optional colon that separates the port
@@ -210,7 +210,6 @@ bool mqtt_connect() {
     if (token != 0) {
       mqtt_port = atoi(token);
     }
-    free(tempstr);
 
     char* MQTTUser = NULL;
     if(MQTTUsername[0]) {


### PR DESCRIPTION
This PR fixes a problem in the MQTT connection code. The problem exists since long time and seem to not affect ESP32, but on Arduino Due for some reason the malloc allocated `tempstr` is destroyed when freed and then the hostname saved in the PubSubClient is therefore corrupted (random bytes at beginning). You can also see this if the log message on serial console contains wrong bytes at beginning of hostname.

As the size of `tempstr` is known from the beginning (it is known at compile time), the whole malloc/free can be removed and instead a static on-stack buffer be used. This also reduces fragmentation of heap.

The only downside is that after the method exists, a pointer to the on-stack buffer is still referenced from the pubsubclient instance. But as it is only required while connection, this does not harm. Maybe we can set it to NULL for safety. But this would also just create a crash on wrong use.

See forum for more info and debugging: https://forum.fhem.de/index.php?msg=1331950