### PR TITLE
Adapt the size of MQTT tempTopic to the size of config variable

### DIFF
--- a/BSB_LAN/include/mqtt_handler.h
+++ b/BSB_LAN/include/mqtt_handler.h
@@ -230,7 +230,7 @@ bool mqtt_connect() {
     } else {
       printlnToDebug("Connected to MQTT broker, updating will topic");
       mqtt_reconnect_timer = 0;
-      char tempTopic[67];
+      char tempTopic[sizeof(MQTTTopicPrefix)+2];
       strcpy(tempTopic, MQTTTopicPrefix);
       strcat(tempTopic, "/#");
       MQTTPubSubClient->subscribe(tempTopic, 1);   //Luposoft: set the topic listen to


### PR DESCRIPTION
Hi @fredlcore,

this is just something I found out while reviewing the code yesterday in PR #717: It adapts the buffersize for creating the topic (for listening on) in the same way like I have done yesterday for the hostname. As before, the sizeof is evaluated by the compiler, so compiled code is identical.

It is up to you to merge this although it fixes no real bug, but it makes the code more safe when modifying config file to larger topic buffer size and it is easier to read.

Uwe