### PR TITLE
safe defaults for bsb bus pins on ESP32C3 and others

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -7599,9 +7599,16 @@ active_cmdtbl_size = sizeof(cmdtbl)/sizeof(cmdtbl[0]);
 #elif defined(ARDUINO_SAM_DUE)
       temp_bus_pins[0] = 19;          // RX2
       temp_bus_pins[1] = 18;          // TX2
+#elif (defined(CONFIG_IDF_TARGET_ESP32))
+      temp_bus_pins[0] = 16;          // NodeMCU ESP32 RX2                                                                                                      
+      temp_bus_pins[1] = 17;          // TX2                                                                                                                    
+#elif (defined(CONFIG_IDF_TARGET_ESP32C3))
+      temp_bus_pins[0] = 20;
+      temp_bus_pins[1] = 21;
 #else
-      temp_bus_pins[0] = 16;          // NodeMCU ESP32 RX2
-      temp_bus_pins[1] = 17;          // TX2
+      printToDebug("Please set bus pins in BSB_LAN_config.h!");
+      for(;;)
+          delay(100);
 #endif
   }
 


### PR DESCRIPTION
The default pin configuration can cause crashes on esp32c3 and maybe others.
Pins 16 and 17 have been defaults for any other processors than those of the predefined boards.
On esp32c3 these pins are flagged red in data sheet. They are used for internal communication to flash storage. Using them as gpio or uart is the safest way to crash the system ;-).

I added some better defaults for C3. Other unknown processors will end in a hint on debug output and an endless loop. I have no better idea, how to keep this change as small as possible.
 