### PR TITLE
Add OTA link to homepage

### DIFF
--- a/BSB_LAN/include/print_webpage.h
+++ b/BSB_LAN/include/print_webpage.h
@@ -124,6 +124,14 @@ void webPrintSite() {
   printlnToWebClient("<p>");
   printToWebClient("BSB-LAN, Version ");
   printToWebClient(BSB_VERSION);
+  if (enable_ota_update) {
+    printToWebClient(" / <a id=\"ota_link\" target=\"_new\">OTA</a>");
+    printToWebClient("<script>");
+    printToWebClient("var port = 8080; var path = '/';");
+    printToWebClient("var proto = (location.protocol === 'https' ? 'https' : 'http');");
+    printToWebClient("document.getElementById('ota_link').href = proto + '://' + location.hostname + ':' + port + path;");
+    printToWebClient("</script>");
+  }
 #if defined(DEFAULT_DEFS)
   if (bus_type < 2) {
     printlnToWebClient("<p><br><b>" MENU_TEXT_SDF "</b><br><br>");


### PR DESCRIPTION
I was confused about how to use OTA to upload the .bin file, and I'm sure I'll forget again sometime in the future, so I added a little helper link right next to the version string. Would this be a useful addition? Never mind if it isn't. 🤭

<img width="670" height="436" alt="image" src="https://github.com/user-attachments/assets/c943d3a8-780b-4139-9460-6c661fb6e406" />
