### PR TITLE
Fix critical buffer overflow vulnerability in HTTP request parsing

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -4640,7 +4640,7 @@ void loop() {
           }
         }
 
-        if ((c!='\n') && (c!='\r') && (bPlaceInBuffer<MaxArrayElement)) {
+        if ((c!='\n') && (c!='\r') && (bPlaceInBuffer<MaxArrayElement-1)) {
           cLineBuffer[bPlaceInBuffer++]=c;
           continue;
         }
@@ -4701,7 +4701,11 @@ void loop() {
             }
           }
         }
-        cLineBuffer[bPlaceInBuffer++]=0;
+        if (bPlaceInBuffer < MaxArrayElement) {
+          cLineBuffer[bPlaceInBuffer++]=0;
+        } else {
+          cLineBuffer[MaxArrayElement-1]=0;  // Ensure null termination
+        }
         // if no credentials found in HTTP header, send 401 Authorization Required
         if (USER_PASS[0] && !(httpflags & HTTP_AUTH) && isSerial == false) {
           printHTTPheader(HTTP_AUTH_REQUIRED, MIME_TYPE_TEXT_HTML, HTTP_ADD_CHARSET_TO_HEADER, HTTP_FILE_NOT_GZIPPED, HTTP_NO_DOWNLOAD, HTTP_DO_NOT_CACHE);


### PR DESCRIPTION
**Disclaimer**: When checking for security vulnerabilities, [Claude Code](https://claude.ai/code) found one for me. This PR fixes it. I let it walk me through the implications and the fix of this pull request. I am an absolute newbie in ESP32 programming and haven't written C in ages. Despite that, I considered opening this PR to be worthwhile, given that the problem description and fix that Claude Code explained to me sounded plausible. Following is the description of the actual problem and change.

---

This fixes a critical off-by-one buffer overflow in the HTTP request
handler that could lead to authentication bypass, information disclosure,
or crashes.

The vulnerability occurred in two places:
1. Line 4643: The buffer filling loop allowed writing up to index 251
   (252 bytes) without leaving room for null terminator
2. Line 4704: Null terminator was added without bounds checking, writing
   at index 252 which is out of bounds

Attack scenario:
- Sending exactly 252 bytes would overflow into bPlaceInBuffer variable
- This would reset the buffer index to 0 and create an unterminated string
- Subsequent string operations (strcpy, strncmp) would read beyond buffer
- Could bypass PASSKEY authentication or leak adjacent memory

Fix:
- Limit buffer filling to MaxArrayElement-1 to reserve space for null
- Add bounds checking before writing null terminator
- Ensure string is always properly null-terminated

This prevents any writes beyond the buffer bounds and eliminates the
authentication bypass vector.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
