### PR TITLE
Handle missing CONFIG_FREERTOS_NUMBER_OF_CORES define for some build environments

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -7801,6 +7801,10 @@ active_cmdtbl_size = sizeof(cmdtbl)/sizeof(cmdtbl[0]);
   //set watchdog timeout 150 seconds
     #define WDT_TIMEOUT 150
   #endif
+  #ifndef CONFIG_FREERTOS_NUMBER_OF_CORES
+  //Fail back to FreeRTOSConfig define for number of cores
+    #define CONFIG_FREERTOS_NUMBER_OF_CORES configNUM_CORES
+  #endif
 //    esp_task_wdt_init(WDT_TIMEOUT, true); //enable panic so ESP32 restarts
   esp_task_wdt_config_t config = {
     .timeout_ms = WDT_TIMEOUT * 1000,  //  60 seconds


### PR DESCRIPTION
When building with `PlatformIO`, this define does not appear to exist in the available libraries. I'm guessing related to which version of the Arduino ESP32 libraries are used for the build.

While trying to fix the build issue, I found an example on the Arduino community forum [here](https://forum.arduino.cc/t/esp32-c3-watch-dog-timer-wdt/1308760/2), in which the example for this watchdog initialisation uses `configNUM_CORES`. This define does exist in `FreeRTOSConfig.h` in the ESP32 libraries, and is defined in my case as 2 which matches the original hard-coded value before this define was used.

I wasn't sure of the source of the selected define, but clearly it exists somewhere in the Arduino IDE otherwise somebody would have noticed by now. So instead of just replacing it, I'm proposing we set a failback define in case the former is missing.