### PR TITLE
Fix stack-buffer overflow in mqtt_callback for topic suffixes ≥ 10 chars

### DIFF
--- a/BSB_LAN/include/mqtt_handler.h
+++ b/BSB_LAN/include/mqtt_handler.h
@@ -590,7 +590,7 @@ void mqtt_callback(char* topic, byte* passed_payload, unsigned int length) {
       return;
     }
   // Publish comma-separated parameters to /poll underneath main topic to update a number of parameters at once
-  } else if (sscanf(topic+topic_len, "/%s", parsed_command) == 1) {
+  } else if (sscanf(topic+topic_len, "/%9s", parsed_command) == 1) {
     if (!strcmp(parsed_command, "poll")) {
       printFmtToDebug("MQTT message received [%s | %s]\r\n", topic, payload);
       char* token;


### PR DESCRIPTION
## Summary

`mqtt_callback()` has an unbounded `%s` in the fallback `sscanf` that writes into a 10-byte stack buffer. When BSB-LAN subscribes to `<MQTTTopicPrefix>/#` and the broker delivers a retained topic whose suffix after the prefix is 10 characters or longer (e.g. `BSB-LAN/0/38/10018`), the call writes past the end of `parsed_command[10]`, smashing the stack canary and triggering a panic on the next function epilogue.

## Reproduction

1. Configure BSB-LAN with MQTT enabled and `log_parameters` containing any 5-digit parameter ID together with a category whose digit count plus parameter ID makes the topic suffix ≥ 10 characters. Example: parameter `10018` in category `38` — suffix `/0/38/10018` is 11 bytes including the null terminator.
2. Let BSB-LAN publish at least once so the broker retains the message under that topic.
3. Reboot BSB-LAN. On reconnect, it subscribes to `<prefix>/#`, the broker replays the retained message, the callback parses it, and the device crashes:
   ```
   Stack smashing protect failure!
   Backtrace: 0x4008d9cc:0x3ffb1d80 ...
   ```
4. Because the message stays retained, the device enters a reboot loop on every restart until the topic is deleted from the broker or the bug is fixed.

## Root cause

In `BSB_LAN/include/mqtt_handler.h`, around line 593:

```c
char parsed_command[10];
...
} else if (sscanf(topic+topic_len, "/%s", parsed_command) == 1) {
```

The first `sscanf` a few lines above already uses the safe form (`%9s`); only this fallback branch was missed.

## Fix

```diff
-  } else if (sscanf(topic+topic_len, "/%s", parsed_command) == 1) {
+  } else if (sscanf(topic+topic_len, "/%9s", parsed_command) == 1) {
```

One-character change. No behavioral effect on valid commands (`poll`, `set`, `inf`, `status` are all ≤ 6 chars). Longer unrecognized suffixes are now safely truncated and still flow into the existing "Unknown command at the end of main MQTT topic" log line.

## Alternative considered

Bumping `parsed_command` to e.g. `char[32]` would also work, but `%9s` is the minimal, surgical fix that mirrors the bound already used in the sibling `sscanf` two lines above. If a larger buffer is preferred for future flexibility, both `sscanf` bounds and the array size should be updated together.

## Notes

- Discovered on a Joy-It ESP32 NodeMCU running BSB-LAN 5.1.1 with a Siemens RVS21.831/127 controller, but the bug is not hardware- or controller-specific — any retained MQTT message with a long enough topic suffix triggers it.
- Recovery without the fix requires deleting the offending retained topic from the broker (e.g. via MQTT Explorer → right-click → Delete) before the device can boot stably again.
