### PR TITLE
Disable WiFi modem sleep to improve latency and prevent long-term packet loss on ESP32

### DIFF
--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -7991,6 +7991,7 @@ active_cmdtbl_size = sizeof(cmdtbl)/sizeof(cmdtbl[0]);
 //    WiFi.enableIPv6();
     if (mDNS_hostname[0]) WiFi.setHostname(mDNS_hostname);
     esp_wifi_set_bandwidth(WIFI_IF_STA, WIFI_BW_HT20);  // W.Bra. 23.03.23 HT20 - reduce bandwidth from 40 to 20 MHz. In 2.4MHz networks, this will increase speed and stability most of the time, or will at worst result in a roughly 10% decrease in transmission speed.
+	WiFi.setSleep(false);  // Disable WiFi modem sleep/power-save, whose beacon/DTIM timing can drift over long uptimes and cause increasing latency/packet loss until the next reboot.
   
     printToDebug("Setting up WiFi interface");
     WiFi.begin();

--- a/BSB_LAN/BSB_LAN.ino
+++ b/BSB_LAN/BSB_LAN.ino
@@ -7991,7 +7991,7 @@ active_cmdtbl_size = sizeof(cmdtbl)/sizeof(cmdtbl[0]);
 //    WiFi.enableIPv6();
     if (mDNS_hostname[0]) WiFi.setHostname(mDNS_hostname);
     esp_wifi_set_bandwidth(WIFI_IF_STA, WIFI_BW_HT20);  // W.Bra. 23.03.23 HT20 - reduce bandwidth from 40 to 20 MHz. In 2.4MHz networks, this will increase speed and stability most of the time, or will at worst result in a roughly 10% decrease in transmission speed.
-	WiFi.setSleep(false);  // Disable WiFi modem sleep/power-save, whose beacon/DTIM timing can drift over long uptimes and cause increasing latency/packet loss until the next reboot.
+	if (esp32_save_energy == false) WiFi.setSleep(false);  // Disable WiFi modem sleep/power-save, whose beacon/DTIM timing can drift over long uptimes and cause increasing latency/packet loss until the next reboot.
   
     printToDebug("Setting up WiFi interface");
     WiFi.begin();


### PR DESCRIPTION
Disable WiFi modem sleep to reduce latency and packet loss. This increases power consumption slightly.
